### PR TITLE
Do not redefine interfaces.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+/tests/ProxyInterfaceSourceGeneratorTests/Destination/Disposable/*.g.cs

--- a/ProxyInterfaceSourceGenerator Solution.sln
+++ b/ProxyInterfaceSourceGenerator Solution.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		PackageReleaseNotes.txt = PackageReleaseNotes.txt
 		README.md = README.md
 		ReleaseNotes.md = ReleaseNotes.md
+		ToDo.md = ToDo.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{19009F5B-3267-45E2-A8B6-89F2AB47D72C}"

--- a/ToDo.md
+++ b/ToDo.md
@@ -1,0 +1,5 @@
+# Ideas for further improvements
+
+## Replaced out parameters
+## Replaced Events
+## Generate explicit interface code

--- a/src/ProxyInterfaceSourceGenerator/Extensions/NamedTypeSymbolExtensions.cs
+++ b/src/ProxyInterfaceSourceGenerator/Extensions/NamedTypeSymbolExtensions.cs
@@ -66,8 +66,7 @@ internal static class NamedTypeSymbolExtensions
         //Members implemented by us or base classes should go here.
         var publicMembers = symbol.GetMembers().Where(m => m.DeclaredAccessibility == Accessibility.Public).ToList();
         //Direct interfaces, recursive interfaces or base class interfaces should go here.
-        var interfaces = new List<INamedTypeSymbol>();
-        interfaces.AddRange(symbol.Interfaces);
+        var interfaces = new List<INamedTypeSymbol>(symbol.Interfaces);
         var baseType = symbol.BaseType;
         while (proxyBaseClasses && baseType != null && baseType.SpecialType != SpecialType.System_Object)
         {
@@ -88,6 +87,7 @@ internal static class NamedTypeSymbolExtensions
                 if (!publicMembers.Contains(implementation!))
                 {
                     isRealized = false;
+                    break;
                 }
             }
             if (isRealized)

--- a/src/ProxyInterfaceSourceGenerator/Extensions/NamedTypeSymbolExtensions.cs
+++ b/src/ProxyInterfaceSourceGenerator/Extensions/NamedTypeSymbolExtensions.cs
@@ -60,4 +60,41 @@ internal static class NamedTypeSymbolExtensions
             $"{namedTypeSymbol}Proxy" :
             $"{namedTypeSymbol}Proxy<{string.Join(", ", namedTypeSymbol.TypeArguments.Select(ta => ta.Name))}>";
     }
+
+    public static List<INamedTypeSymbol> ResolveImplementedInterfaces(this INamedTypeSymbol symbol, bool proxyBaseClasses)
+    {
+        //Members implemented by us or base classes should go here.
+        var publicMembers = symbol.GetMembers().Where(m => m.DeclaredAccessibility == Accessibility.Public).ToList();
+        //Direct interfaces, recursive interfaces or base class interfaces should go here.
+        var interfaces = new List<INamedTypeSymbol>();
+        interfaces.AddRange(symbol.Interfaces);
+        var baseType = symbol.BaseType;
+        while (proxyBaseClasses && baseType != null && baseType.SpecialType != SpecialType.System_Object)
+        {
+            publicMembers.AddRange(baseType.GetMembers().Where(m => m.DeclaredAccessibility == Accessibility.Public));
+            interfaces.AddRange(baseType.Interfaces);
+            baseType = baseType.BaseType;
+        }
+
+        //Filter explicitly implemented interfaces.
+        var realizedInterfaces = new List<INamedTypeSymbol>();
+        foreach (var iface in interfaces)
+        {
+            var isRealized = true;
+            var allMembers = iface.AllInterfaces.Aggregate(iface.GetMembers(), (xs, x) => xs.AddRange(x.GetMembers()));
+            foreach (var member in allMembers)
+            {
+                var implementation = symbol.FindImplementationForInterfaceMember(member);
+                if (!publicMembers.Contains(implementation!))
+                {
+                    isRealized = false;
+                }
+            }
+            if (isRealized)
+            {
+                realizedInterfaces.Add(iface);
+            }
+        }
+        return realizedInterfaces;
+    }
 }

--- a/src/ProxyInterfaceSourceGenerator/FileGenerators/PartialInterfacesGenerator.cs
+++ b/src/ProxyInterfaceSourceGenerator/FileGenerators/PartialInterfacesGenerator.cs
@@ -60,9 +60,8 @@ internal class PartialInterfacesGenerator : BaseGenerator, IFilesGenerator
     {
         var extendsProxyClasses = GetExtendsProxyData(proxyData, classSymbol);
         ImplementedInterfaces = classSymbol.Symbol.ResolveImplementedInterfaces(proxyData.ProxyBaseClasses);
-        IEnumerable<string> implementedInterfacesNames = ImplementedInterfaces.Select(i => i.ToDisplayString(NullableFlowState.None, SymbolDisplayFormat.FullyQualifiedFormat));
-        var implements = string.Join(", ", implementedInterfacesNames);
-        implements = string.IsNullOrEmpty(implements) ? string.Empty : $" : {implements}";
+        var implementedInterfacesNames = ImplementedInterfaces.Select(i => i.ToDisplayString(NullableFlowState.None, SymbolDisplayFormat.FullyQualifiedFormat));
+        var implements = implementedInterfacesNames.Any() ? $" : {string.Join(", ", implementedInterfacesNames)}" : string.Empty;
         var @new = extendsProxyClasses.Any() ? "new " : string.Empty;
         var (namespaceStart, namespaceEnd) = NamespaceBuilder.Build(ns);
 
@@ -103,11 +102,9 @@ using System;
             {
                 hashSet.Add(member.Name);
             }
-
         }
         //Member is not already implemented in another interface.
-        bool func(T t) => !hashSet.Contains(t.Name);
-        return func;
+        return (T t) => !hashSet.Contains(t.Name);
     }
 
     private string GenerateProperties(ClassSymbol targetClassSymbol, bool proxyBaseClasses)

--- a/src/ProxyInterfaceSourceGenerator/FileGenerators/ProxyClassesGenerator.cs
+++ b/src/ProxyInterfaceSourceGenerator/FileGenerators/ProxyClassesGenerator.cs
@@ -82,7 +82,7 @@ internal partial class ProxyClassesGenerator : BaseGenerator, IFilesGenerator
         var operators = GenerateOperators(targetClassSymbol, pd.ProxyBaseClasses);
 
         var configurationForMapster = string.Empty;
-        if (Context.ReplacedTypes.Any())
+        if (Context.ReplacedTypes.Count > 0)
         {
             configurationForMapster = GenerateMapperConfigurationForMapster();
         }

--- a/tests/ProxyInterfaceSourceGeneratorTests/InheritedInterfaceTests.cs
+++ b/tests/ProxyInterfaceSourceGeneratorTests/InheritedInterfaceTests.cs
@@ -7,162 +7,158 @@ using ProxyInterfaceSourceGenerator;
 using ProxyInterfaceSourceGeneratorTests.Source.Disposable;
 using Xunit.Abstractions;
 
-namespace ProxyInterfaceSourceGeneratorTests
+namespace ProxyInterfaceSourceGeneratorTests;
+
+public class InheritedInterfaceTests
 {
-    public class InheritedInterfaceTests
+    private const string Namespace = "ProxyInterfaceSourceGeneratorTests.Source.Disposable";
+    private const string OutputPath = "../../../Destination/Disposable/";
+    private readonly ProxyInterfaceCodeGenerator _sut;
+
+    public InheritedInterfaceTests(ITestOutputHelper output)
     {
-        private const string Namespace = "ProxyInterfaceSourceGeneratorTests.Source.Disposable";
-        private const string OutputPath = "../../../Destination/Disposable/";
-        private readonly ProxyInterfaceCodeGenerator _Dut;
-        private readonly ITestOutputHelper _Output;
-
-        public InheritedInterfaceTests(ITestOutputHelper output)
+        if (!Directory.Exists(OutputPath))
         {
-            if (!Directory.Exists(OutputPath))
+            Directory.CreateDirectory(OutputPath);
+        }
+        _sut = new ProxyInterfaceCodeGenerator();
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public void GenerateFiles_InheritedInterface_InheritFromBaseClass(bool proxyBaseClass, bool inheritBaseInterface)
+    {
+        var name = "Child";
+        var interfaceName = "I" + name;
+        var proxyName = name + "Proxy";
+
+        // Arrange
+        string[] fileNames = [
+        $"{Namespace}.{interfaceName}.g.cs",
+        $"{Namespace}.{proxyName}.g.cs"
+        ];
+        var path = $"./Source/Disposable/{interfaceName}.cs";
+        SourceFile sourceFile = CreateSourceFile(path, name, proxyBaseClass);
+
+        // Act
+        var result = _sut.Execute([sourceFile]);
+
+        result.Valid.Should().BeTrue();
+        result.Files.Should().HaveCount(fileNames.Length + 1);
+        WriteFiles(fileNames, result);
+
+        var interfaceIndex = 1;
+        var tree = result.Files[interfaceIndex].SyntaxTree;
+        var root = tree.GetRoot();
+        var interfaceDeclarations = root.DescendantNodes().OfType<InterfaceDeclarationSyntax>();
+
+        // Assert
+        Assert.Single(interfaceDeclarations);
+        var baseList = interfaceDeclarations.First().BaseList;
+        bool didWeInherit = baseList is not null;
+        Assert.Equal(didWeInherit, inheritBaseInterface);
+    }
+
+    [Theory]
+    [InlineData("Parent")]
+    [InlineData("Child")]
+    public void GenerateFiles_InheritedInterface_Should_InheritTheInterface(string name)
+    {
+        var interfaceName = "I" + name;
+        var proxyName = name + "Proxy";
+
+        // Arrange
+        string[] fileNames = [
+        $"{Namespace}.{interfaceName}.g.cs",
+        $"{Namespace}.{proxyName}.g.cs"
+        ];
+
+        var path = $"./Source/Disposable/{interfaceName}.cs";
+        SourceFile sourceFile = CreateSourceFile(path, name, true);
+
+        // Act
+        var result = _sut.Execute([sourceFile]);
+
+        result.Valid.Should().BeTrue();
+        result.Files.Should().HaveCount(fileNames.Length + 1);
+        WriteFiles(fileNames, result);
+
+        var interfaceIndex = 1;
+        var tree = result.Files[interfaceIndex].SyntaxTree;
+        var root = tree.GetRoot();
+        var interfaceDeclarations = root.DescendantNodes().OfType<InterfaceDeclarationSyntax>();
+
+        // Assert
+        Assert.Single(interfaceDeclarations);
+        var baseList = interfaceDeclarations.First().BaseList!;
+        Assert.Equal(2, baseList.Types.Count);
+        var type1 = (QualifiedNameSyntax)baseList.Types[0].Type;
+        var type2 = (QualifiedNameSyntax)baseList.Types[1].Type;
+        Assert.Equal(nameof(IDisposable), type1.Right.Identifier.Text);
+        Assert.Equal(nameof(IUpdate<string>), type2.Right.Identifier.Text);
+    }
+
+    [Fact]
+    public void GenerateFiles_InheritedInterface_Should_Not_InheritExplicitImplementedInterfaces()
+    {
+        var name = "Explicit";
+        var interfaceName = "I" + name;
+        var proxyName = name + "Proxy";
+
+        // Arrange
+        string[] fileNames = [
+        $"{Namespace}.{interfaceName}.g.cs",
+        $"{Namespace}.{proxyName}.g.cs"
+        ];
+        var interfaceIndex = 1;
+        var path = $"./Source/Disposable/{interfaceName}.cs";
+        SourceFile sourceFile = CreateSourceFile(path, name, true);
+
+        // Act
+        var result = _sut.Execute([sourceFile]);
+
+        result.Valid.Should().BeTrue();
+        result.Files.Should().HaveCount(fileNames.Length + 1);
+        WriteFiles(fileNames, result);
+
+        var tree = result.Files[interfaceIndex].SyntaxTree;
+        var root = tree.GetRoot();
+        var interfaceDeclarations = root.DescendantNodes().OfType<InterfaceDeclarationSyntax>();
+
+        // Assert
+        //This actually could work, we just need to implenent the logic inside the Proxy (and interface).
+        //⚠ Dispose is not a public member of the 'Explicit' class and also not of the Proxy.
+        //e.g. new Explicit().Dipose() is not possible.
+        Assert.Single(interfaceDeclarations);
+        var baseList = interfaceDeclarations.First().BaseList;
+        bool noInterfaceImplementationFound = baseList is null;
+        Assert.True(noInterfaceImplementationFound);
+    }
+
+    private static SourceFile CreateSourceFile(string path, string name, bool extend)
+    {
+        var extendString = extend.ToString().ToLowerInvariant();
+        return new SourceFile
+        {
+            Path = path,
+            Text = File.ReadAllText(path),
+            AttributeToAddToInterface = new ExtraAttribute
             {
-                Directory.CreateDirectory(OutputPath);
+                Name = "ProxyInterfaceGenerator.Proxy",
+                ArgumentList = $"typeof({Namespace}.{name}), {extendString}"
             }
-            _Dut = new ProxyInterfaceCodeGenerator();
-            _Output = output;
-        }
+        };
+    }
 
-        [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, true)]
-        public void GenerateFiles_InheritedInterface_InheritFromBaseClass(bool proxyBaseClass, bool inheritBaseInterface)
+    private static void WriteFiles(string[] fileNames, ExecuteResult result)
+    {
+        foreach (var fileName in fileNames.Select((fileName, index) => new { fileName, index }))
         {
-            var name = "Child";
-            var interfaceName = "I" + name;
-            var proxyName = name + "Proxy";
-
-            // Arrange
-            string[] fileNames = [
-            $"{Namespace}.{interfaceName}.g.cs",
-            $"{Namespace}.{proxyName}.g.cs"
-            ];
-            var path = $"./Source/Disposable/{interfaceName}.cs";
-            SourceFile sourceFile = CreateSourceFile(path, name, proxyBaseClass);
-
-            // Act
-            var result = _Dut.Execute([sourceFile]);
-
-            result.Valid.Should().BeTrue();
-            result.Files.Should().HaveCount(fileNames.Length + 1);
-            WriteFiles(fileNames, result);
-
-            var interfaceIndex = 1;
-            var tree = result.Files[interfaceIndex].SyntaxTree;
-            var root = tree.GetRoot();
-            var interfaceDeclarations = root.DescendantNodes().OfType<InterfaceDeclarationSyntax>();
-
-            // Assert
-            Assert.Single(interfaceDeclarations);
-            var baseList = interfaceDeclarations.First().BaseList;
-            bool ditWeInherit = baseList is not null;
-            Assert.Equal(ditWeInherit, inheritBaseInterface);
-        }
-
-        [Theory]
-        [InlineData("Parent")]
-        [InlineData("Child")]
-        public void GenerateFiles_InheritedInterface_Should_InheritTheInterface(string name)
-        {
-            var interfaceName = "I" + name;
-            var proxyName = name + "Proxy";
-
-            // Arrange
-            string[] fileNames = [
-            $"{Namespace}.{interfaceName}.g.cs",
-            $"{Namespace}.{proxyName}.g.cs"
-            ];
-
-
-            var path = $"./Source/Disposable/{interfaceName}.cs";
-            SourceFile sourceFile = CreateSourceFile(path, name, true);
-
-            // Act
-            var result = _Dut.Execute([sourceFile]);
-
-            result.Valid.Should().BeTrue();
-            result.Files.Should().HaveCount(fileNames.Length + 1);
-            WriteFiles(fileNames, result);
-
-            var interfaceIndex = 1;
-            var tree = result.Files[interfaceIndex].SyntaxTree;
-            var root = tree.GetRoot();
-            var interfaceDeclarations = root.DescendantNodes().OfType<InterfaceDeclarationSyntax>();
-
-            // Assert
-            Assert.Single(interfaceDeclarations);
-            var baseList = interfaceDeclarations.First().BaseList!;
-            Assert.Equal(2, baseList.Types.Count);
-            var type1 = (QualifiedNameSyntax)baseList.Types[0].Type;
-            var type2 = (QualifiedNameSyntax)baseList.Types[1].Type;
-            Assert.Equal(nameof(IDisposable), type1.Right.Identifier.Text);
-            Assert.Equal(nameof(IUpdate<string>), type2.Right.Identifier.Text);
-        }
-
-        [Fact]
-        public void GenerateFiles_InheritedInterface_Should_Not_InheritExplicitImplementedInterfaces()
-        {
-            var name = "Explicit";
-            var interfaceName = "I" + name;
-            var proxyName = name + "Proxy";
-
-            // Arrange
-            string[] fileNames = [
-            $"{Namespace}.{interfaceName}.g.cs",
-            $"{Namespace}.{proxyName}.g.cs"
-            ];
-            var interfaceIndex = 1;
-            var path = $"./Source/Disposable/{interfaceName}.cs";
-            SourceFile sourceFile = CreateSourceFile(path, name, true);
-
-            // Act
-            var result = _Dut.Execute([sourceFile]);
-
-            result.Valid.Should().BeTrue();
-            result.Files.Should().HaveCount(fileNames.Length + 1);
-            WriteFiles(fileNames, result);
-
-            var tree = result.Files[interfaceIndex].SyntaxTree;
-            var root = tree.GetRoot();
-            var interfaceDeclarations = root.DescendantNodes().OfType<InterfaceDeclarationSyntax>();
-
-            // Assert
-            //This actually could work, we just need to implenent the logic inside the Proxy (and interface).
-            //⚠ Dispose is not a public member of the 'Explicit' class and also not of the Proxy.
-            //e.g. new Explicit().Dipose() is not possible.
-            Assert.Single(interfaceDeclarations);
-            var baseList = interfaceDeclarations.First().BaseList;
-            bool noInterfaceImplementationFound = baseList is null;
-            Assert.True(noInterfaceImplementationFound);
-        }
-
-        private static SourceFile CreateSourceFile(string path, string name, bool extend)
-        {
-            var extendString = extend.ToString().ToLowerInvariant();
-            return new SourceFile
-            {
-                Path = path,
-                Text = File.ReadAllText(path),
-                AttributeToAddToInterface = new ExtraAttribute
-                {
-                    Name = "ProxyInterfaceGenerator.Proxy",
-                    ArgumentList = $"typeof({Namespace}.{name}), {extendString}"
-                }
-            };
-        }
-
-        private static void WriteFiles(string[] fileNames, ExecuteResult result)
-        {
-            foreach (var fileName in fileNames.Select((fileName, index) => new { fileName, index }))
-            {
-                var builder = result.Files[fileName.index + 1]; // +1 means skip the attribute
-                builder.Path.Should().EndWith(fileName.fileName);
-                File.WriteAllText($"{OutputPath}{fileName.fileName}", builder.Text);
-                builder.Text.Should().Be(File.ReadAllText($"{OutputPath}{fileName.fileName}"));
-            }
+            var builder = result.Files[fileName.index + 1]; // +1 means skip the attribute
+            builder.Path.Should().EndWith(fileName.fileName);
+            File.WriteAllText($"{OutputPath}{fileName.fileName}", builder.Text);
+            builder.Text.Should().Be(File.ReadAllText($"{OutputPath}{fileName.fileName}"));
         }
     }
 }

--- a/tests/ProxyInterfaceSourceGeneratorTests/InheritedInterfaceTests.cs
+++ b/tests/ProxyInterfaceSourceGeneratorTests/InheritedInterfaceTests.cs
@@ -1,0 +1,168 @@
+using CSharp.SourceGenerators.Extensions;
+using CSharp.SourceGenerators.Extensions.Models;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using ProxyInterfaceSourceGenerator;
+using ProxyInterfaceSourceGeneratorTests.Source.Disposable;
+using Xunit.Abstractions;
+
+namespace ProxyInterfaceSourceGeneratorTests
+{
+    public class InheritedInterfaceTests
+    {
+        private const string Namespace = "ProxyInterfaceSourceGeneratorTests.Source.Disposable";
+        private const string OutputPath = "../../../Destination/Disposable/";
+        private readonly ProxyInterfaceCodeGenerator _Dut;
+        private readonly ITestOutputHelper _Output;
+
+        public InheritedInterfaceTests(ITestOutputHelper output)
+        {
+            if (!Directory.Exists(OutputPath))
+            {
+                Directory.CreateDirectory(OutputPath);
+            }
+            _Dut = new ProxyInterfaceCodeGenerator();
+            _Output = output;
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        public void GenerateFiles_InheritedInterface_InheritFromBaseClass(bool proxyBaseClass, bool inheritBaseInterface)
+        {
+            var name = "Child";
+            var interfaceName = "I" + name;
+            var proxyName = name + "Proxy";
+
+            // Arrange
+            string[] fileNames = [
+            $"{Namespace}.{interfaceName}.g.cs",
+            $"{Namespace}.{proxyName}.g.cs"
+            ];
+            var path = $"./Source/Disposable/{interfaceName}.cs";
+            SourceFile sourceFile = CreateSourceFile(path, name, proxyBaseClass);
+
+            // Act
+            var result = _Dut.Execute([sourceFile]);
+
+            result.Valid.Should().BeTrue();
+            result.Files.Should().HaveCount(fileNames.Length + 1);
+            WriteFiles(fileNames, result);
+
+            var interfaceIndex = 1;
+            var tree = result.Files[interfaceIndex].SyntaxTree;
+            var root = tree.GetRoot();
+            var interfaceDeclarations = root.DescendantNodes().OfType<InterfaceDeclarationSyntax>();
+
+            // Assert
+            Assert.Single(interfaceDeclarations);
+            var baseList = interfaceDeclarations.First().BaseList;
+            bool ditWeInherit = baseList is not null;
+            Assert.Equal(ditWeInherit, inheritBaseInterface);
+        }
+
+        [Theory]
+        [InlineData("Parent")]
+        [InlineData("Child")]
+        public void GenerateFiles_InheritedInterface_Should_InheritTheInterface(string name)
+        {
+            var interfaceName = "I" + name;
+            var proxyName = name + "Proxy";
+
+            // Arrange
+            string[] fileNames = [
+            $"{Namespace}.{interfaceName}.g.cs",
+            $"{Namespace}.{proxyName}.g.cs"
+            ];
+
+
+            var path = $"./Source/Disposable/{interfaceName}.cs";
+            SourceFile sourceFile = CreateSourceFile(path, name, true);
+
+            // Act
+            var result = _Dut.Execute([sourceFile]);
+
+            result.Valid.Should().BeTrue();
+            result.Files.Should().HaveCount(fileNames.Length + 1);
+            WriteFiles(fileNames, result);
+
+            var interfaceIndex = 1;
+            var tree = result.Files[interfaceIndex].SyntaxTree;
+            var root = tree.GetRoot();
+            var interfaceDeclarations = root.DescendantNodes().OfType<InterfaceDeclarationSyntax>();
+
+            // Assert
+            Assert.Single(interfaceDeclarations);
+            var baseList = interfaceDeclarations.First().BaseList!;
+            Assert.Equal(2, baseList.Types.Count);
+            var type1 = (QualifiedNameSyntax)baseList.Types[0].Type;
+            var type2 = (QualifiedNameSyntax)baseList.Types[1].Type;
+            Assert.Equal(nameof(IDisposable), type1.Right.Identifier.Text);
+            Assert.Equal(nameof(IUpdate<string>), type2.Right.Identifier.Text);
+        }
+
+        [Fact]
+        public void GenerateFiles_InheritedInterface_Should_Not_InheritExplicitImplementedInterfaces()
+        {
+            var name = "Explicit";
+            var interfaceName = "I" + name;
+            var proxyName = name + "Proxy";
+
+            // Arrange
+            string[] fileNames = [
+            $"{Namespace}.{interfaceName}.g.cs",
+            $"{Namespace}.{proxyName}.g.cs"
+            ];
+            var interfaceIndex = 1;
+            var path = $"./Source/Disposable/{interfaceName}.cs";
+            SourceFile sourceFile = CreateSourceFile(path, name, true);
+
+            // Act
+            var result = _Dut.Execute([sourceFile]);
+
+            result.Valid.Should().BeTrue();
+            result.Files.Should().HaveCount(fileNames.Length + 1);
+            WriteFiles(fileNames, result);
+
+            var tree = result.Files[interfaceIndex].SyntaxTree;
+            var root = tree.GetRoot();
+            var interfaceDeclarations = root.DescendantNodes().OfType<InterfaceDeclarationSyntax>();
+
+            // Assert
+            //This actually could work, we just need to implenent the logic inside the Proxy (and interface).
+            //⚠ Dispose is not a public member of the 'Explicit' class and also not of the Proxy.
+            //e.g. new Explicit().Dipose() is not possible.
+            Assert.Single(interfaceDeclarations);
+            var baseList = interfaceDeclarations.First().BaseList;
+            bool noInterfaceImplementationFound = baseList is null;
+            Assert.True(noInterfaceImplementationFound);
+        }
+
+        private static SourceFile CreateSourceFile(string path, string name, bool extend)
+        {
+            var extendString = extend.ToString().ToLowerInvariant();
+            return new SourceFile
+            {
+                Path = path,
+                Text = File.ReadAllText(path),
+                AttributeToAddToInterface = new ExtraAttribute
+                {
+                    Name = "ProxyInterfaceGenerator.Proxy",
+                    ArgumentList = $"typeof({Namespace}.{name}), {extendString}"
+                }
+            };
+        }
+
+        private static void WriteFiles(string[] fileNames, ExecuteResult result)
+        {
+            foreach (var fileName in fileNames.Select((fileName, index) => new { fileName, index }))
+            {
+                var builder = result.Files[fileName.index + 1]; // +1 means skip the attribute
+                builder.Path.Should().EndWith(fileName.fileName);
+                File.WriteAllText($"{OutputPath}{fileName.fileName}", builder.Text);
+                builder.Text.Should().Be(File.ReadAllText($"{OutputPath}{fileName.fileName}"));
+            }
+        }
+    }
+}

--- a/tests/ProxyInterfaceSourceGeneratorTests/InheritedInterfaceTests.cs
+++ b/tests/ProxyInterfaceSourceGeneratorTests/InheritedInterfaceTests.cs
@@ -15,7 +15,7 @@ public class InheritedInterfaceTests
     private const string OutputPath = "../../../Destination/Disposable/";
     private readonly ProxyInterfaceCodeGenerator _sut;
 
-    public InheritedInterfaceTests(ITestOutputHelper output)
+    public InheritedInterfaceTests()
     {
         if (!Directory.Exists(OutputPath))
         {

--- a/tests/ProxyInterfaceSourceGeneratorTests/ProxyInterfaceSourceGeneratorTests.csproj
+++ b/tests/ProxyInterfaceSourceGeneratorTests/ProxyInterfaceSourceGeneratorTests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <LangVersion>10.0</LangVersion>
+        <LangVersion>12.0</LangVersion>
         <Nullable>enable</Nullable>
         <Configurations>Debug;Release;DebugAttach</Configurations>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -52,10 +52,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Destination\AkkaGenerated\" />
-    </ItemGroup>
-
-    <ItemGroup>
+        <Compile Update="Source\Disposable\*.cs">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Compile>
         <Compile Update="Source\Generic.cs">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Compile>

--- a/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/Child.cs
+++ b/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/Child.cs
@@ -1,0 +1,6 @@
+namespace ProxyInterfaceSourceGeneratorTests.Source.Disposable
+{
+    public class Child : Parent
+    {
+    }
+}

--- a/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/Explicit.cs
+++ b/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/Explicit.cs
@@ -1,0 +1,25 @@
+namespace ProxyInterfaceSourceGeneratorTests.Source.Disposable
+{
+    public class Explicit : IDisposable, IUpdate<string>
+    {
+        string IUpdate<string>.Name => throw new NotSupportedException();
+
+        event EventHandler<string>? IUpdate<string>.Update
+        {
+            add
+            {
+                throw new NotSupportedException();
+            }
+
+            remove
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        void IDisposable.Dispose()
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/IChild.cs
+++ b/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/IChild.cs
@@ -1,0 +1,6 @@
+namespace ProxyInterfaceSourceGeneratorTests.Source.Disposable
+{
+    public partial interface IChild
+    {
+    }
+}

--- a/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/IExplicit.cs
+++ b/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/IExplicit.cs
@@ -1,0 +1,6 @@
+namespace ProxyInterfaceSourceGeneratorTests.Source.Disposable
+{
+    public partial interface IExplicit
+    {
+    }
+}

--- a/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/IParent.cs
+++ b/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/IParent.cs
@@ -1,0 +1,6 @@
+namespace ProxyInterfaceSourceGeneratorTests.Source.Disposable
+{
+    public partial interface IParent
+    {
+    }
+}

--- a/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/IUpdate.cs
+++ b/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/IUpdate.cs
@@ -1,0 +1,9 @@
+namespace ProxyInterfaceSourceGeneratorTests.Source.Disposable
+{
+    public interface IUpdate<T>
+    {
+        event EventHandler<T>? Update;
+
+        string Name { get; }
+    }
+}

--- a/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/Parent.cs
+++ b/tests/ProxyInterfaceSourceGeneratorTests/Source/Disposable/Parent.cs
@@ -1,0 +1,45 @@
+namespace ProxyInterfaceSourceGeneratorTests.Source.Disposable
+{
+    public class Parent : IDisposable, IUpdate<string>
+    {
+        private bool disposedValue;
+
+        public event EventHandler<string>? Update;
+
+        public string Name => nameof(Parent);
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        public bool Empty()
+        {
+            return false;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects)
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                disposedValue = true;
+            }
+        }
+
+        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+        // ~TrashCan()
+        // {
+        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        //     Dispose(disposing: false);
+        // }
+    }
+}


### PR DESCRIPTION
If the original class implements `IDisposable`.
I want the Proxy class to also implement `IDisposable`, so that `using` can be used and analyzers are able check for missing calls to `Dispose`.

The software shall not redefine but reuse interfaces implemented by the original class. 